### PR TITLE
modify: [チャット機能] Vueインスタンスのコンパイル終了までバインディング非表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       v-model="yourname"
     >
     <!-- システム選択 -->
-    <select v-model="selectedSystem" name="systems" size="1" >
+    <select v-model="selectedSystem" name="systems" size="1">
         <option selected></option>
         <option v-for="system in systems">{{system}}</option>
     </select>

--- a/index.html
+++ b/index.html
@@ -22,23 +22,24 @@
       v-model="yourname"
     >
     <!-- システム選択 -->
-    <select v-model="selectedSystem" name="systems" size="1">
+    <select v-model="selectedSystem" name="systems" size="1" >
+        <option selected></option>
         <option v-for="system in systems">{{system}}</option>
-    </select>  
+    </select>
     <input
       v-model="inputbox"
       v-on:keyup.enter="sendMessage(yourname,selectedSystem)"
       placeholder="input message here"
       style="width:400px"
     >
-    <button 
+    <button
       @click="sendMessage(yourname,selectedSystem)"
       id="button"
     >
     send Message
     </button>
     <div id="chatmessages">
-      <div v-for="message in messages">{{message.text}}</div>
+      <div v-for="message in messages" v-cloak>{{message.text}}</div>
     </div>
   </div>
   <script src="/js/constants.js"></script>

--- a/www/css/ddntj.css
+++ b/www/css/ddntj.css
@@ -6,7 +6,7 @@ body{
 #header{
   margin: 0px;
   padding: 5px;
-  background-color: #ccffcc  
+  background-color: #ccffcc;
 }
 #header ul{
   font-size:0;
@@ -52,4 +52,8 @@ body{
   width: 300px;
   height: 100px;
   background-color: #A2F9AF;
+}
+
+[v-cloak] {
+  display:none;
 }


### PR DESCRIPTION
現在、HTMLのロード終了からVue.jsによるコンパイルが終了するまで、
Mustacheのバインディング({{ hogehoge }}的なやつ)が見えっぱなので
Vue.jsが提供する機能で非表示。

また、ダイスボットのシステム選択リストも同様の問題があるため、
デフォルトの選択オプションとして空文字列を追加。