### PR TITLE
feat: [チャット機能]チャットボックスのレイアウト変更

### DIFF
--- a/www/css/ddntj.css
+++ b/www/css/ddntj.css
@@ -25,22 +25,6 @@ body{
   text-align: right;
 }
 
-#chatbox{
-  width: 800px;
-  height: 150px;
-  border: solid #808080;
-  padding: 0.5em;
-  position: relative;
-}
-#chatmessages{
-  position: absolute;
-  overflow-y: scroll;
-  font-size: 12px;
-  top: 70px;
-  bottom: 5px;
-  left: 5px;
-  right: 5px;
-}
 .dropArea {
   padding: 0;
   margin: 0;


### PR DESCRIPTION
Close #13 .
# 内容
- チャットボックス初期位置を画面下へ
- チャットボックス内部レイアウトをメッセージボックスを上、
入力関係を下の配置へ
- 複数行入力に対応
- Enterで入力、Shift+Enterで改行
- メッセージボックスは最下部までスクロールしているときに限り
最新メッセージ受信時に最新メッセージまで追従。

# まとめ
全体的にどどんとふのレイアウトに近づける。

# スクリーンショット
<img width="1121" alt="2017-08-25 13 54 27" src="https://user-images.githubusercontent.com/13959762/29700336-9e0b0f36-899e-11e7-9db3-8699221e65dc.png">
<img width="828" alt="2017-08-25 14 00 30" src="https://user-images.githubusercontent.com/13959762/29700344-b50fb380-899e-11e7-96b6-310926cc9cec.png">
<img width="826" alt="2017-08-25 14 00 53" src="https://user-images.githubusercontent.com/13959762/29700351-bd56a2ec-899e-11e7-94f8-bc9a299e47eb.png">

